### PR TITLE
「10.Scalaの文法の落ち穂拾い」で用いたコードのマージ

### DIFF
--- a/scala-fp/.idea/scala_compiler.xml
+++ b/scala-fp/.idea/scala_compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ScalaCompilerConfiguration">
     <profile name="sbt 1" modules="scala-fp">
+      <option name="macros" value="true" />
       <parameters>
         <parameter value="-encoding" />
         <parameter value="UTF-8" />

--- a/scala-fp/build.sbt
+++ b/scala-fp/build.sbt
@@ -4,10 +4,14 @@ version := "0.1"
 
 scalaVersion := "2.12.10"
 
+scalacOptions in Global += "-language:experimental.macros"
+
 scalastyleSources in Compile := (unmanagedSourceDirectories in Compile).value
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
 libraryDependencies += "org.mockito" % "mockito-core" % "2.21.0" % "test"
+
+libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
 
 scalacOptions ++= Seq("-encoding", "UTF-8")

--- a/scala-fp/src/main/scala/MacroChallenge.scala
+++ b/scala-fp/src/main/scala/MacroChallenge.scala
@@ -1,0 +1,16 @@
+import scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
+
+// Challenge 10-3
+
+object MacroChallenge {
+  def asserteq(left: Int, right: Int, msg: Any) = macro asserteqImpl
+
+  def asserteqImpl(c: Context)
+    (left: c.Expr[Int], right: c.Expr[Int], msg: c.Expr[Any]) : c.Expr[Unit] = {
+    import c.universe._
+    reify {
+      assert(left.splice.equals( right.splice) , msg.splice)
+    }
+  }
+}

--- a/scala-fp/src/main/scala/MacroStudy.scala
+++ b/scala-fp/src/main/scala/MacroStudy.scala
@@ -1,0 +1,12 @@
+import language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object MacroStudy {
+  def accessor(obj: Any, property: String): Any = macro impl_accessor
+
+  def impl_accessor(c: Context)(obj: c.Expr[Any], property: c.Expr[String]): c.universe.Select = {
+    import c.universe._
+    val Expr(Literal(Constant(propString: String))) = property
+    Select(obj.tree, TermName(propString))
+  }
+}

--- a/scala-fp/src/main/scala/ReflectionChallenge.scala
+++ b/scala-fp/src/main/scala/ReflectionChallenge.scala
@@ -1,0 +1,23 @@
+// Challenge 10-2
+import scala.reflect.runtime.universe._
+
+class Issue(private val title: String) {
+  private def printTitle(): Unit = println(title)
+}
+
+object ReflectionChallenge {
+  val issue = new Issue("不具合1")
+
+  def run(): Unit = {
+    // TypeTag[Issue].tpe.decl
+    val m = runtimeMirror(getClass.getClassLoader)
+    val classIssue = typeOf[Issue].typeSymbol.asClass
+
+    val printTitleTermSymbol = typeOf[Issue].decl(TermName("printTitle")).asMethod
+
+    val im = m.reflect(issue)
+    val printTitleMirror = im.reflectMethod(printTitleTermSymbol)
+
+    printTitleMirror()
+  }
+}

--- a/scala-fp/src/main/scala/ReflectionStudy.scala
+++ b/scala-fp/src/main/scala/ReflectionStudy.scala
@@ -1,0 +1,17 @@
+import scala.reflect.runtime.universe._
+
+object ReflectionStudy {
+
+  def main(): Unit = {
+    println("========= from class =========")
+    println(typeTag[Option[_]].tpe.decls)
+
+    val list = List(1,2,3)
+
+    def getTypeTagFromList[T: TypeTag](list: List[T]) : TypeTag[T] = typeTag[T]
+
+    println("========= from type parameter =========")
+    println(getTypeTagFromList(list).tpe.decls)
+  }
+
+}

--- a/scala-fp/src/main/scala/UnapplyChallenge.scala
+++ b/scala-fp/src/main/scala/UnapplyChallenge.scala
@@ -1,0 +1,11 @@
+// Challenge 10-1
+
+object UnapplyChallenge {
+  class Book(private val title: String)
+
+  object Book {
+    def unapply(book: Book): Option[String] = {
+      Some(book.title)
+    }
+  }
+}

--- a/scala-fp/src/main/scala/UnapplyStudy.scala
+++ b/scala-fp/src/main/scala/UnapplyStudy.scala
@@ -1,0 +1,33 @@
+import scala.util.Try
+
+object UnapplyStudy extends App {
+
+  class User(private val name: String, private val age: Int)
+
+  object User {
+    def unapply(obj: Any): Option[(String, Int)] =
+      obj match {
+        case user: User =>
+          Some((user.name, user.age))
+        case str: String =>
+          val strs = str.split("@")
+          val name = strs.headOption
+          val age = Try {
+            strs.tail.headOption.map(_.toInt)
+          }.toOption.flatten
+          (name, age) match {
+            case (Some(n), Some(a)) => Some((n, a))
+            case _ => None
+          }
+        case _ =>
+          None
+      }
+  }
+
+  def printPatternMatched(obj: AnyRef): Unit = {
+    obj match {
+      case User(name, age) => println(s"Name: ${name}, Age: ${age}")
+      case _ => println("can't extract")
+    }
+  }
+}

--- a/scala-fp/src/test/scala/MacroStudySpec.scala
+++ b/scala-fp/src/test/scala/MacroStudySpec.scala
@@ -1,0 +1,9 @@
+import org.scalatest.{DiagrammedAssertions, FlatSpec}
+
+class MacroStudySpec  extends FlatSpec with DiagrammedAssertions {
+  it should "構文から、指定した引数を取り出す" in {
+    case class User(name: String)
+    val user = User("taro")
+    assert(MacroStudy.accessor(user, "name") === "taro")
+  }
+}

--- a/scala-fp/src/test/scala/UnapplyStudySpec.scala
+++ b/scala-fp/src/test/scala/UnapplyStudySpec.scala
@@ -1,0 +1,9 @@
+import org.scalatest.{DiagrammedAssertions, FlatSpec}
+import UnapplyStudy._
+
+class UnapplyStudySpec extends FlatSpec with DiagrammedAssertions  {
+  it should "文字でもUserでもパターンマッチできる" in {
+    printPatternMatched(new User("Taro", 17))
+    printPatternMatched("Jiro@16")
+  }
+}


### PR DESCRIPTION
## 学んだこと
- unapply
- リフレクション
- マクロ

## 所感
- unapplyは、rustでも同様のことができるので、とても便利
- リフレクションは、Scalaなのに動的言語書いている感じがした。
- 上級の回答例では、デバッグマクロを作っていたが、C++のように、__LINE__とかのコンパイラに代入してもらう事前定義マクロみたいのないのかな？わざわざ構文解析してやるにしては大袈裟な気がした。