### PR TITLE
「12.パーサーコンビネーターで作るJSONパーサー」で用いたコードのマージ

### DIFF
--- a/parsercombinator/build.sbt
+++ b/parsercombinator/build.sbt
@@ -3,3 +3,5 @@ name := "parsercombinator"
 version := "0.1"
 
 scalaVersion := "2.12.10"
+
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"

--- a/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/ArithParser.scala
+++ b/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/ArithParser.scala
@@ -1,0 +1,10 @@
+package jp.ed.nnn.parsercombinator
+// Challenge 12-1
+
+object ArithParser extends Combinator {
+  def expr: Parser[Any] = term ~ rep(s("+") ~ term | s("-") ~ term)
+  def term: Parser[Any] = factor ~ rep(s("*") ~ factor | s("/") ~ factor)
+  def factor: Parser[Any] = floatingPointNumber | s("(") ~> expr <~ s(")")
+
+  def apply(input: String): Any = factor(input)
+}

--- a/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/Combinator.scala
+++ b/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/Combinator.scala
@@ -1,0 +1,162 @@
+package jp.ed.nnn.parsercombinator
+
+import scala.util.matching.Regex
+
+abstract class Combinator {
+
+  sealed trait ParseResult[+T]
+  case class Success[+T](value: T, next: String) extends ParseResult[T]
+  case object Failure extends ParseResult[Nothing]
+
+  type Parser[+T] = String => ParseResult[T]
+
+  def string(literal: String): Parser[String] = input => {
+    if(input.startsWith(literal)) {
+      Success(literal, input.substring(literal.length))
+    } else {
+      Failure
+    }
+  }
+
+  def oneOf(chars: Seq[Char]) : Parser[String] = input => {
+    if (input.nonEmpty && chars.contains(input.head)) {
+      Success(input.head.toString, input.tail)
+    } else {Failure}
+  }
+
+  // Challenge 12=3
+  def spacing: Parser[String] = rep(oneOf(Seq(' ', '\t', '\r', '\n'))) ^^ {_.mkString}
+
+  /**
+   * string parser
+   * @param literal 文字列
+   * @return
+   */
+  def s(literal: String): Parser[String] = string(literal)
+
+  def ss(literal: String): Parser[String] = s(literal) <~ spacing
+
+  def rep[T](parser: => Parser[T]): Parser[List[T]] = input => {
+
+    def repeatRec(input: String): (List[T], String) = parser(input) match {
+      case Success(value, next1) =>
+        val (result, next2) = repeatRec(next1)
+        (value::result, next2)
+      case Failure => (Nil, input)
+    }
+
+    val (result, next) = repeatRec(input)
+    Success(result, next)
+  }
+
+  def rep1sep[T](parser: => Parser[T], sep: Parser[String]): Parser[List[T]] =
+    parser ~ rep(sep ~> parser) ^^ {t => t._1 :: t._2}
+
+  def success[T](value: T): Parser[T] = input => Success(value, input)
+
+  def repsep[T](parser: => Parser[T], sep: Parser[String]): Parser[List[T]] =
+    rep1sep(parser, sep) | success(List())
+
+  def regexMatch(r: Regex): Parser[String] = input => {
+    val matchIterator = r.findAllIn(input).matchData
+    if(matchIterator.hasNext) {
+      val next = matchIterator.next()
+      val all = next.group(0)
+      val target = next.group(1)
+      Success(target, input.substring(all.length))
+    } else {
+      Failure
+    }
+  }
+
+  val floatingPointNumber: Parser[String] = input => {
+    val r: Regex = """^(-?\d+(\.\d*)?|\d*\.\d+)([eE][+-]?\d+)?[fFdD]?""".r
+    regexMatch(r)(input)
+  }
+
+  val stringLiteral: Parser[String] = input =>  {
+    val r = ("^\"("+"""([^"\p{Cntrl}\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*+"""+")\"").r
+    regexMatch(r)(input)
+  }
+
+
+  implicit class RichParser[T](val parser: Parser[T]) {
+    /**
+     * select
+     *
+     * @param right 選択を行うパーサー
+     * @return
+     */
+
+    def |[U >: T](right: => Parser[U]): Parser[U] = input => {
+      parser(input) match {
+        case success@Success(_, _) => success
+        case Failure => right(input)
+      }
+    }
+
+    /**
+     * combine
+     *
+     * @param right 逐次合成を行うパーサ
+     * @tparam U パーサーの結果の型
+     * @return
+     */
+    def ~[U](right: => Parser[U]):Parser[(T, U)] = input => {
+      parser(input) match {
+        case Success(value1, next1) =>
+          right(next1) match {
+            case Success(value2, next2) => Success((value1, value2), next2)
+            case Failure => Failure
+          }
+        case Failure => Failure
+      }
+    }
+
+    /**
+     * map
+     *
+     * @param function 適用する関数
+     * @tparam U パーサーの結果の型
+     * @return
+     */
+    def ^^[U](function: T => U): Parser[U] = input => {
+      parser(input) match {
+        case Success(value, next) => Success(function(value), next)
+        case Failure => Failure
+      }
+    }
+
+    /**
+     * user left
+     * @param right right side parser
+     * @return
+     */
+    def <~(right: => Parser[Any]): Parser[T] = input => {
+      parser(input) match {
+        case Success(value1, next1) =>
+          right(next1) match {
+            case Success(value2, next2) => Success(value1, next2)
+            case Failure => Failure
+          }
+        case Failure => Failure
+      }
+    }
+
+    /**
+     * use right
+     * @param right right side parser
+     * @return
+     */
+    def ~>[U](right: => Parser[U]): Parser[U] = input => {
+      parser(input) match {
+        case Success(value1, next1) =>
+          right(next1) match {
+            case Success(value2, next2) => Success(value2, next2)
+            case Failure => Failure
+          }
+        case Failure => Failure
+      }
+    }
+  }
+}

--- a/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/JSONParser.scala
+++ b/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/JSONParser.scala
@@ -1,0 +1,27 @@
+package jp.ed.nnn.parsercombinator
+
+// Challenge 12-3
+
+object JSONParser extends Combinator {
+
+  def obj: Parser[Map[String, Any]]  =
+    ss("{") ~> repsep(member, ss(",")) <~ ss("}") <~ spacing ^^ { Map() ++ _ }
+
+  def arr: Parser[List[Any]] =
+    ss("[") ~> repsep(value, ss(",")) <~ ss("]") <~ spacing
+
+  def member: Parser[(String, Any)] =
+    (stringLiteral <~ spacing) ~ ss(":") ~ value <~ spacing  ^^ { t => (t._1._1, t._2) }
+
+  def value: Parser[Any] =
+    obj  |
+      arr  |
+      stringLiteral <~ spacing |
+      (floatingPointNumber <~ spacing ^^ { _.toDouble })  |
+      ss("null") ^^  { _ => null } |
+      ss("true") ^^  { _ => true } |
+      ss("false") ^^  { _ => false }
+
+  def apply(input: String): Any = value(input)
+
+}

--- a/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/JavaTokenParsersJSONParser.scala
+++ b/parsercombinator/src/main/scala/jp/ed/nnn/parsercombinator/JavaTokenParsersJSONParser.scala
@@ -1,0 +1,24 @@
+package jp.ed.nnn.parsercombinator
+// Challenge 12-2
+
+import scala.util.parsing.combinator.JavaTokenParsers
+
+object JavaTokenParsersJSONParser extends JavaTokenParsers {
+  def obj: Parser[Map[String, Any]] = "{" ~> repsep(member, ",") <~ "}" ^^ {
+    Map() ++ _
+  }
+
+  def arr: Parser[List[Any]] = "[" ~> repsep(value, ",") <~ "]"
+
+  def member: Parser[(String, Any)] =
+    stringLiteral ~ ":" ~ value ^^ { t => (t._1._1, t._2)}
+
+  def value: Parser[Any] =
+    obj | arr | stringLiteral |
+      (floatingPointNumber ^^ {_.toDouble}) |
+      "null" ^^ { _ => null} |
+      "true" ^^ { _ => true} |
+      "false" ^^ {_ => false}
+
+  def apply(input : String): Any = parseAll(value, input)
+}


### PR DESCRIPTION
## 学んだこと
- JSONのBNF
- パーサーコンビネータにおけるimplicit classの使い方

## 所感
- 挑戦の上級の解答例、spacing全てに入れることで解決してるけど、objとか、arrは、それ自体でスペース削除してるからいらないし、適当に加えた感があり、なんか気に食わない。入れる意味があるなら教えて欲しい。
- scala-parser-combinatorsでは、string 自体を拡張して ~> とかの構文を解析してるのかな。implicit class をうまく使うととても便利だとわかって、面白い
- 挑戦の上級、どこに実装しろとか具体的に明言されてなくて困った。文章を読むと、中級で実装したJavaTokenParsersJSONParserでスペースを弾けるようにしろということにも読み取れるので、テキストを誤解が少なくなるように修正して欲しい。
